### PR TITLE
Fix undefined errors when project first started

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -4,9 +4,9 @@ import { RichText, Link } from 'prismic-reactjs'
 const Header = ({ menu = [] }) => (
     <header className="site-header">
       <a href="/" className="logo">
-        {RichText.asText(menu.data.title)}
+        {RichText.asText(menu.data?.title)}
       </a>
-      <Links menuLinks={menu.data.menu_links} />
+      <Links menuLinks={menu.data?.menu_links} />
       <style jsx>{`
         .site-header {
           height: 30px;


### PR DESCRIPTION
When following [this tutorial](https://prismic.io/docs/technologies/launch-an-example-slice-machine-project-next.js) if the user starts the dev server before they have added title and links to their project they will get an undefined error. This is simple to avoid by checking to see if data is undefined and we can and show the "Your SliceZone is Empty" text instead.

